### PR TITLE
Add boolean values and schema type checks

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod engine;
 pub mod parser;
 
-pub use engine::{Engine, Row, Table, Value, EngineError};
+pub use engine::{Engine, Row, Table, Value, ValueType, EngineError};
 pub use parser::{parse_query, parse_select, parse_insert, Query, SelectQuery, InsertQuery};

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -1,6 +1,6 @@
 use nom::{
     branch::alt,
-    bytes::complete::{tag, take_while1},
+    bytes::complete::{tag, tag_no_case, take_while1},
     character::complete::{char, digit1, multispace0, multispace1},
     combinator::{map, map_res},
     multi::separated_list0,
@@ -39,7 +39,11 @@ fn parse_value(i: &str) -> IResult<&str, Value> {
         delimited(char('\''), take_while1(|c| c != '\''), char('\'')),
         |s: &str| Value::Text(s.to_string()),
     );
-    alt((parse_int, parse_string))(i)
+    let parse_bool = alt((
+        map(tag_no_case("TRUE"), |_| Value::Bool(true)),
+        map(tag_no_case("FALSE"), |_| Value::Bool(false)),
+    ));
+    alt((parse_int, parse_string, parse_bool))(i)
 }
 
 fn parse_values(i: &str) -> IResult<&str, Vec<Value>> {

--- a/core/tests/basic.rs
+++ b/core/tests/basic.rs
@@ -1,9 +1,15 @@
-use sql_core::{Engine, Value, parse_query};
+use sql_core::{Engine, Value, ValueType, parse_query};
 
 #[test]
 fn basic_flow() {
     let mut engine = Engine::new();
-    engine.create_table("users", vec!["id".into(), "name".into()]);
+    engine.create_table(
+        "users",
+        vec![
+            ("id".into(), ValueType::Int),
+            ("name".into(), ValueType::Text),
+        ],
+    );
 
     let insert_q = parse_query("INSERT INTO users VALUES (1, 'Alice')").unwrap().1;
     engine.execute(insert_q).unwrap();
@@ -12,4 +18,24 @@ fn basic_flow() {
     let rows = engine.execute(select_q).unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0], vec![Value::Int(1), Value::Text("Alice".into())]);
+}
+
+#[test]
+fn bool_flow() {
+    let mut engine = Engine::new();
+    engine.create_table(
+        "flags",
+        vec![
+            ("id".into(), ValueType::Int),
+            ("active".into(), ValueType::Bool),
+        ],
+    );
+
+    let insert_q = parse_query("INSERT INTO flags VALUES (1, TRUE)").unwrap().1;
+    engine.execute(insert_q).unwrap();
+
+    let select_q = parse_query("SELECT * FROM flags WHERE active=TRUE").unwrap().1;
+    let rows = engine.execute(select_q).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0], vec![Value::Int(1), Value::Bool(true)]);
 }


### PR DESCRIPTION
## Summary
- support Bool in the core Value enum and introduce ValueType
- enforce schema-aware type checking during inserts
- parse SQL TRUE/FALSE and test boolean flows

## Testing
- `make test` *(fails: failed to download from https://index.crates.io/config.json [403])*


------
https://chatgpt.com/codex/tasks/task_e_68ac7c94a6688332bcbab93be3b96e96